### PR TITLE
Update Java doc to reflect recent image changes

### DIFF
--- a/using_images/s2i_images/java.adoc
+++ b/using_images/s2i_images/java.adoc
@@ -13,15 +13,15 @@ toc::[]
 [[s2i-images-java-overview]]
 == Overview
 
-{product-title} provides an
+{product-title} provides
 xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I
-builder image] for building Java applications.  This builder image takes your
+builder images] for building Java applications.  These builder images take your
 application source or binary artifacts, builds the source using Maven (if source
-was provided), and assembles the artifacts with any required dependencies to
+was provided), and assemble the artifacts with any required dependencies to
 create a new, ready-to-run image containing your Java application. This
 resulting image can be run on {product-title} or run directly with Docker.
 
-The builder image is intended for use with
+The builder images are intended for use with
 link:https://maven.apache.org[Maven]-based Java standalone projects that are run
 via main class.
 
@@ -29,8 +29,8 @@ via main class.
 [[s2i-images-java-versions]]
 == Versions
 
-The current version of the Java S2I builder image supports OpenJDK 1.8, Jolokia
-1.3.5, and Maven 3.3.9-2.8.
+The current version of the Java S2I builder images support OpenJDK 1.8 and 11,
+Jolokia 1.6.2, and Maven 3.6.
 
 
 [[s2i-images-java-images]]
@@ -40,6 +40,9 @@ The RHEL 7 image is available through the Red Hat Registry:
 
 ----
 $ docker pull registry.redhat.io/redhat-openjdk-18/openjdk18-openshift
+$ docker pull registry.redhat.io/openjdk/openjdk-11-rhel7
+$ docker pull registry.redhat.io/ubi8/openjdk-8
+$ docker pull registry.redhat.io/ubi8/openjdk-11
 ----
 
 ifdef::openshift-online[]
@@ -69,7 +72,7 @@ By default, the Java S2I builder image uses Maven to build the project with the
 following goals and options:
 
 ----
-mvn -Dmaven.repo.local=/tmp/artifacts/m2 -s /tmp/artifacts/configuration/settings.xml -e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true package -Djava.net.preferIPv4Stack=true
+mvn -e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true --batch-mode -Djava.net.preferIPv4Stack=true -s /tmp/artifacts/configuration/settings.xml -Dmaven.repo.local=/tmp/artifacts/m2  package
 ----
 
 Based on these defaults, the builder image compiles the project and copies all
@@ -85,14 +88,19 @@ You can override these default goals and options by specifying the following env
 
 |Variable name |Description
 
-|`*ARTIFACT_DIR*`
-|The relative path to the target where JAR files are created for multi-module builds.
+|`*MAVEN_S2I_ARTIFACT_DIRS*`
+|Relative paths of source directories to scan for build output, which will be copied to $DEPLOY_DIR. Defaults to **target**
 
 |`*JAVA_MAIN_CLASS*`
 |The main class to use as the argument to Java. This can also be specified in the *_.s2i/environment_* file as a Maven property inside the project (*docker.env.Main*).
+|A main class to use as argument for `java`. When this environment variable is given, all jar files in `JAVA_APP_DIR` are added to the classpath as well as `JAVA_LIB_DIR`.
 
 |`*MAVEN_ARGS*`
-|The arguments that are passed to the mvn command.
+|The arguments that are passed to the mvn command. Defining this replaces the defaults,
+| which are `-e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga package`.
+
+|`*MAVEN_ARGS_APPEND*`
+|Additional Maven arguments.
 
 |===
 
@@ -155,13 +163,13 @@ following command:
 
 ifdef::openshift-online[]
 ----
-$ oc new-app redhat-openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='ARTIFACT_DIR=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
+$ oc new-app redhat-openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='MAVEN_S2I_ARTIFACT_DIRS=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
 ----
 endif::openshift-online[]
 
 ifndef::openshift-online[]
 ----
-$ oc new-app registry.redhat.io/redhat-openjdk-18/openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='ARTIFACT_DIR=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
+$ oc new-app registry.redhat.io/redhat-openjdk-18/openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='MAVEN_S2I_ARTIFACT_DIRS=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
 ----
 endif::openshift-online[]
 


### PR DESCRIPTION
There are now four Java images (matrix of RHEL7/RHEL8 and JDK8/JDK11).
Update the blurb and reference to JDK versions accordingly.

Update the version of the included Jolokia and Maven versions.

Add a further three example "docker pull" commands for the other image
variants. Their names are hopefully self explanatory wrt RHEL and Java
version (the original one is the least clear from the name)

Update the default Maven arguments example and the list of environment
variables for configuring Maven in an S2I build. There are actually
many more variables that can be used, but I'm not sure whether this
document should be comprehensive. Please let me know what you think.
Here's an (also out of date) list of variables, to give an idea of the size:
<https://jmtd.net/tmp/openjdk-container-docs/ubi8-openjdk-11.html>

ARTIFACT_DIR was deprecated in favour of MAVEN_S2I_ARTIFACT_DIRS.
Update the final examples to reflect this.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>